### PR TITLE
Rework of PKs to split out parseParameterList, make SetEvaluator() call EnsureEvaluators() 

### DIFF
--- a/03_surface_water/bc_critical_depth.xml
+++ b/03_surface_water/bc_critical_depth.xml
@@ -56,7 +56,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0,9}" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/03_surface_water/bc_max_head.xml
+++ b/03_surface_water/bc_max_head.xml
@@ -56,7 +56,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0,9}" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/03_surface_water/bc_zero_gradient.xml
+++ b/03_surface_water/bc_zero_gradient.xml
@@ -56,7 +56,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0,9}" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/03_surface_water/rainfall_fv.xml
+++ b/03_surface_water/rainfall_fv.xml
@@ -56,7 +56,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0,9}" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/03_surface_water/rainfall_fv_jac.xml
+++ b/03_surface_water/rainfall_fv_jac.xml
@@ -56,7 +56,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0,9}" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/03_surface_water/rainfall_fv_simplified.xml
+++ b/03_surface_water/rainfall_fv_simplified.xml
@@ -56,7 +56,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0,9}" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/1d_dist_tiles.xml
+++ b/04_integrated_hydro/1d_dist_tiles.xml
@@ -150,7 +150,6 @@
       <Parameter name="primary variable key" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
@@ -179,7 +178,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="false" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">
         <Parameter name="discretization primary" type="string" value="fv: default" />

--- a/04_integrated_hydro/1d_dist_tiles_orig.xml
+++ b/04_integrated_hydro/1d_dist_tiles_orig.xml
@@ -150,7 +150,6 @@
       <Parameter name="primary variable key" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
@@ -179,7 +178,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="false" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">
         <Parameter name="discretization primary" type="string" value="fv: default" />

--- a/04_integrated_hydro/3d_dist_tiles-np2.xml
+++ b/04_integrated_hydro/3d_dist_tiles-np2.xml
@@ -134,7 +134,6 @@
       <Parameter name="primary variable key" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
@@ -173,7 +172,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="false" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">
         <Parameter name="discretization primary" type="string" value="fv: default" />

--- a/04_integrated_hydro/3d_dist_tiles-np2_orig.xml
+++ b/04_integrated_hydro/3d_dist_tiles-np2_orig.xml
@@ -131,7 +131,6 @@
       <Parameter name="primary variable key" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
@@ -170,7 +169,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="false" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">
         <Parameter name="discretization primary" type="string" value="fv: default" />

--- a/04_integrated_hydro/column_drainage.xml
+++ b/04_integrated_hydro/column_drainage.xml
@@ -180,7 +180,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="false" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/column_drainage_orig.xml
+++ b/04_integrated_hydro/column_drainage_orig.xml
@@ -177,7 +177,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="false" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/column_exfiltration.xml
+++ b/04_integrated_hydro/column_exfiltration.xml
@@ -180,7 +180,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="false" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/column_exfiltration_orig.xml
+++ b/04_integrated_hydro/column_exfiltration_orig.xml
@@ -177,7 +177,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="false" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/column_inf.xml
+++ b/04_integrated_hydro/column_inf.xml
@@ -244,7 +244,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="source key" type="string" value="precipitation_rain" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />

--- a/04_integrated_hydro/column_inf_orig.xml
+++ b/04_integrated_hydro/column_inf_orig.xml
@@ -238,7 +238,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="source key" type="string" value="precipitation_rain" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />

--- a/04_integrated_hydro/column_infiltration2.xml
+++ b/04_integrated_hydro/column_infiltration2.xml
@@ -153,7 +153,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="source key" type="string" value="precipitation_rain" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">
         <Parameter name="discretization primary" type="string" value="fv: default" />

--- a/04_integrated_hydro/column_infiltration2_orig.xml
+++ b/04_integrated_hydro/column_infiltration2_orig.xml
@@ -150,7 +150,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="source key" type="string" value="precipitation_rain" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">
         <Parameter name="discretization primary" type="string" value="fv: default" />

--- a/04_integrated_hydro/column_sat.xml
+++ b/04_integrated_hydro/column_sat.xml
@@ -240,7 +240,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="source key" type="string" value="precipitation_rain" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/column_sat_orig.xml
+++ b/04_integrated_hydro/column_sat_orig.xml
@@ -237,7 +237,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="source key" type="string" value="precipitation_rain" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/hillslope_inf-np2.xml
+++ b/04_integrated_hydro/hillslope_inf-np2.xml
@@ -173,7 +173,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{4}" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />

--- a/04_integrated_hydro/hillslope_inf-np2_orig.xml
+++ b/04_integrated_hydro/hillslope_inf-np2_orig.xml
@@ -170,7 +170,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{4}" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />

--- a/04_integrated_hydro/hillslope_inf.xml
+++ b/04_integrated_hydro/hillslope_inf.xml
@@ -169,7 +169,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/hillslope_inf_orig.xml
+++ b/04_integrated_hydro/hillslope_inf_orig.xml
@@ -166,7 +166,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/hillslope_sat-np2.xml
+++ b/04_integrated_hydro/hillslope_sat-np2.xml
@@ -174,7 +174,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/hillslope_sat-np2_orig.xml
+++ b/04_integrated_hydro/hillslope_sat-np2_orig.xml
@@ -171,7 +171,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/hillslope_sat.xml
+++ b/04_integrated_hydro/hillslope_sat.xml
@@ -179,7 +179,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/04_integrated_hydro/hillslope_sat_orig.xml
+++ b/04_integrated_hydro/hillslope_sat_orig.xml
@@ -166,7 +166,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />
       </ParameterList>

--- a/05_surface_balance/lingzhang_rsoil-sakagucki_zeng.xml
+++ b/05_surface_balance/lingzhang_rsoil-sakagucki_zeng.xml
@@ -131,7 +131,6 @@
       <Parameter name="primary variable key" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="clobber surface rel perm" type="bool" value="false" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
@@ -171,7 +170,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">
         <Parameter name="discretization primary" type="string" value="fv: default" />

--- a/05_surface_balance/lingzhang_rsoil-sellers.xml
+++ b/05_surface_balance/lingzhang_rsoil-sellers.xml
@@ -128,7 +128,6 @@
       <Parameter name="primary variable key" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="clobber surface rel perm" type="bool" value="false" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
@@ -168,7 +167,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">
         <Parameter name="discretization primary" type="string" value="fv: default" />

--- a/05_surface_balance/lingzhang_subgrid.xml
+++ b/05_surface_balance/lingzhang_subgrid.xml
@@ -147,7 +147,6 @@
       <Parameter name="primary variable key" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="clobber surface rel perm" type="bool" value="false" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
@@ -191,7 +190,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />

--- a/08_energy/coupled_flow_energy1.xml
+++ b/08_energy/coupled_flow_energy1.xml
@@ -202,7 +202,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-precipitation_rain" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">
@@ -270,7 +269,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="flux key" type="string" value="surface-mass_flux" />
       <Parameter name="supress advective terms in preconditioner" type="bool" value="true" />

--- a/08_energy/coupled_flow_energy1.xml
+++ b/08_energy/coupled_flow_energy1.xml
@@ -340,7 +340,7 @@
       <ParameterList name="surface-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/coupled_flow_energy1_orig.xml
+++ b/08_energy/coupled_flow_energy1_orig.xml
@@ -338,7 +338,7 @@
       <ParameterList name="surface-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/coupled_flow_energy1_orig.xml
+++ b/08_energy/coupled_flow_energy1_orig.xml
@@ -200,7 +200,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-precipitation_rain" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">
@@ -268,7 +267,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="flux key" type="string" value="surface-mass_flux" />
       <Parameter name="supress advective terms in preconditioner" type="bool" value="true" />

--- a/08_energy/coupled_flow_energy2.xml
+++ b/08_energy/coupled_flow_energy2.xml
@@ -354,7 +354,7 @@
       <ParameterList name="surface-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/coupled_flow_energy2_orig.xml
+++ b/08_energy/coupled_flow_energy2_orig.xml
@@ -352,7 +352,7 @@
       <ParameterList name="surface-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/coupled_flow_energy3.xml
+++ b/08_energy/coupled_flow_energy3.xml
@@ -354,7 +354,7 @@
       <ParameterList name="surface-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/coupled_flow_energy3_orig.xml
+++ b/08_energy/coupled_flow_energy3_orig.xml
@@ -352,7 +352,7 @@
       <ParameterList name="surface-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/coupled_flow_energy4.xml
+++ b/08_energy/coupled_flow_energy4.xml
@@ -354,7 +354,7 @@
       <ParameterList name="surface-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/coupled_flow_energy4_orig.xml
+++ b/08_energy/coupled_flow_energy4_orig.xml
@@ -352,7 +352,7 @@
       <ParameterList name="surface-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/freeze_thaw_subsurface.xml
+++ b/08_energy/freeze_thaw_subsurface.xml
@@ -132,7 +132,6 @@
       <Parameter name="domain name" type="string" value="domain" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="270.15" />

--- a/08_energy/freeze_thaw_surface.xml
+++ b/08_energy/freeze_thaw_surface.xml
@@ -135,7 +135,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="270.15" />

--- a/08_energy/freezeup.xml
+++ b/08_energy/freezeup.xml
@@ -278,7 +278,7 @@
           <Parameter name="verbosity level" type="string" value="low" />
         </ParameterList>
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <Parameter name="molar density key" type="string" value="molar_density_liquid" />

--- a/08_energy/freezeup_orig.xml
+++ b/08_energy/freezeup_orig.xml
@@ -275,7 +275,7 @@
           <Parameter name="verbosity level" type="string" value="low" />
         </ParameterList>
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <Parameter name="molar density key" type="string" value="molar_density_liquid" />

--- a/08_energy/permafrost-wrm_brookscorey-krel_brookscorey.xml
+++ b/08_energy/permafrost-wrm_brookscorey-krel_brookscorey.xml
@@ -196,7 +196,6 @@
       <Parameter name="domain name" type="string" value="domain" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="unsaturated" />
@@ -236,7 +235,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="initial time step" type="double" value="86400" />
       <ParameterList name="diffusion" type="ParameterList">
@@ -258,7 +256,6 @@
       <Parameter name="primary variable key" type="string" value="temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="initial time step" type="double" value="86400" />
       <Parameter name="include thermal advection" type="bool" value="false" />
       <Parameter name="explicit advection" type="bool" value="false" />
@@ -309,7 +306,6 @@
       <Parameter name="primary variable key" type="string" value="surface-temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="flux key" type="string" value="surface-water_flux" />
       <Parameter name="include thermal advection" type="bool" value="false" />
@@ -347,7 +343,6 @@
       <Parameter name="conserved quantity key" type="string" value="snow-water_volume" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="snow-source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="0.35" />
       </ParameterList>

--- a/08_energy/permafrost-wrm_brookscorey-krel_brookscorey.xml
+++ b/08_energy/permafrost-wrm_brookscorey-krel_brookscorey.xml
@@ -372,7 +372,7 @@
       <ParameterList name="water_content" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="liquid+ice water content" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/permafrost-wrm_brookscorey-krel_brookscorey_orig.xml
+++ b/08_energy/permafrost-wrm_brookscorey-krel_brookscorey_orig.xml
@@ -373,7 +373,7 @@
       <ParameterList name="water_content" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="liquid+ice water content" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/permafrost-wrm_brookscorey-krel_brookscorey_orig.xml
+++ b/08_energy/permafrost-wrm_brookscorey-krel_brookscorey_orig.xml
@@ -197,7 +197,6 @@
       <Parameter name="domain name" type="string" value="domain" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="unsaturated" />
@@ -237,7 +236,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="initial time step" type="double" value="86400" />
       <ParameterList name="diffusion" type="ParameterList">
@@ -259,7 +257,6 @@
       <Parameter name="primary variable key" type="string" value="temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="initial time step" type="double" value="86400" />
       <Parameter name="include thermal advection" type="bool" value="false" />
       <Parameter name="explicit advection" type="bool" value="false" />
@@ -310,7 +307,6 @@
       <Parameter name="primary variable key" type="string" value="surface-temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="flux key" type="string" value="surface-water_flux" />
       <Parameter name="include thermal advection" type="bool" value="false" />
@@ -348,7 +344,6 @@
       <Parameter name="conserved quantity key" type="string" value="snow-water_volume" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="snow-source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="0.35" />
       </ParameterList>

--- a/08_energy/permafrost-wrm_vangenuchten-krel_brookscorey.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_brookscorey.xml
@@ -196,7 +196,6 @@
       <Parameter name="domain name" type="string" value="domain" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="unsaturated" />
@@ -236,7 +235,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="initial time step" type="double" value="86400" />
       <ParameterList name="diffusion" type="ParameterList">
@@ -258,7 +256,6 @@
       <Parameter name="primary variable key" type="string" value="temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="initial time step" type="double" value="86400" />
       <Parameter name="include thermal advection" type="bool" value="false" />
       <Parameter name="explicit advection" type="bool" value="false" />
@@ -309,7 +306,6 @@
       <Parameter name="primary variable key" type="string" value="surface-temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="flux key" type="string" value="surface-water_flux" />
       <Parameter name="include thermal advection" type="bool" value="false" />
@@ -347,7 +343,6 @@
       <Parameter name="conserved quantity key" type="string" value="snow-water_volume" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="snow-source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="0.35" />
       </ParameterList>

--- a/08_energy/permafrost-wrm_vangenuchten-krel_brookscorey.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_brookscorey.xml
@@ -372,7 +372,7 @@
       <ParameterList name="water_content" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="liquid+ice water content" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/permafrost-wrm_vangenuchten-krel_brookscorey_orig.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_brookscorey_orig.xml
@@ -373,7 +373,7 @@
       <ParameterList name="water_content" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="liquid+ice water content" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/permafrost-wrm_vangenuchten-krel_brookscorey_orig.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_brookscorey_orig.xml
@@ -197,7 +197,6 @@
       <Parameter name="domain name" type="string" value="domain" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="unsaturated" />
@@ -237,7 +236,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="initial time step" type="double" value="86400" />
       <ParameterList name="diffusion" type="ParameterList">
@@ -259,7 +257,6 @@
       <Parameter name="primary variable key" type="string" value="temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="initial time step" type="double" value="86400" />
       <Parameter name="include thermal advection" type="bool" value="false" />
       <Parameter name="explicit advection" type="bool" value="false" />
@@ -310,7 +307,6 @@
       <Parameter name="primary variable key" type="string" value="surface-temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="flux key" type="string" value="surface-water_flux" />
       <Parameter name="include thermal advection" type="bool" value="false" />
@@ -348,7 +344,6 @@
       <Parameter name="conserved quantity key" type="string" value="snow-water_volume" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="snow-source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="0.35" />
       </ParameterList>

--- a/08_energy/permafrost-wrm_vangenuchten-krel_sutraice.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_sutraice.xml
@@ -196,7 +196,6 @@
       <Parameter name="domain name" type="string" value="domain" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="unsaturated" />
@@ -236,7 +235,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="initial time step" type="double" value="86400" />
       <ParameterList name="diffusion" type="ParameterList">
@@ -258,7 +256,6 @@
       <Parameter name="primary variable key" type="string" value="temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="initial time step" type="double" value="86400" />
       <Parameter name="include thermal advection" type="bool" value="false" />
       <Parameter name="explicit advection" type="bool" value="false" />
@@ -309,7 +306,6 @@
       <Parameter name="primary variable key" type="string" value="surface-temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="flux key" type="string" value="surface-water_flux" />
       <Parameter name="include thermal advection" type="bool" value="false" />
@@ -347,7 +343,6 @@
       <Parameter name="conserved quantity key" type="string" value="snow-water_volume" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="snow-source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="0.35" />
       </ParameterList>

--- a/08_energy/permafrost-wrm_vangenuchten-krel_sutraice.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_sutraice.xml
@@ -372,7 +372,7 @@
       <ParameterList name="water_content" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="liquid+ice water content" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/permafrost-wrm_vangenuchten-krel_sutraice_orig.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_sutraice_orig.xml
@@ -373,7 +373,7 @@
       <ParameterList name="water_content" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="liquid+ice water content" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/permafrost-wrm_vangenuchten-krel_sutraice_orig.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_sutraice_orig.xml
@@ -197,7 +197,6 @@
       <Parameter name="domain name" type="string" value="domain" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="unsaturated" />
@@ -237,7 +236,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="initial time step" type="double" value="86400" />
       <ParameterList name="diffusion" type="ParameterList">
@@ -259,7 +257,6 @@
       <Parameter name="primary variable key" type="string" value="temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="initial time step" type="double" value="86400" />
       <Parameter name="include thermal advection" type="bool" value="false" />
       <Parameter name="explicit advection" type="bool" value="false" />
@@ -310,7 +307,6 @@
       <Parameter name="primary variable key" type="string" value="surface-temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="flux key" type="string" value="surface-water_flux" />
       <Parameter name="include thermal advection" type="bool" value="false" />
@@ -348,7 +344,6 @@
       <Parameter name="conserved quantity key" type="string" value="snow-water_volume" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="snow-source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="0.35" />
       </ParameterList>

--- a/08_energy/permafrost-wrm_vangenuchten-krel_vangenuchten.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_vangenuchten.xml
@@ -196,7 +196,6 @@
       <Parameter name="domain name" type="string" value="domain" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="unsaturated" />
@@ -237,7 +236,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="initial time step" type="double" value="86400" />
       <ParameterList name="diffusion" type="ParameterList">
@@ -260,7 +258,6 @@
       <Parameter name="primary variable key" type="string" value="temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="initial time step" type="double" value="86400" />
       <Parameter name="include thermal advection" type="bool" value="false" />
       <Parameter name="explicit advection" type="bool" value="false" />
@@ -312,7 +309,6 @@
       <Parameter name="primary variable key" type="string" value="surface-temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="flux key" type="string" value="surface-water_flux" />
       <Parameter name="include thermal advection" type="bool" value="false" />
@@ -351,7 +347,6 @@
       <Parameter name="conserved quantity key" type="string" value="snow-water_volume" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="snow-source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="0.35" />
       </ParameterList>

--- a/08_energy/permafrost-wrm_vangenuchten-krel_vangenuchten.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_vangenuchten.xml
@@ -227,6 +227,7 @@
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="restart file" type="string" value="../data/energy_freezeup_checkpoint_final.h5" />
       </ParameterList>
+      <Parameter name="debug cells" type="Array(int)" value="{99}" />
 
     </ParameterList>
 
@@ -249,6 +250,7 @@
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="initialize surface head from subsurface" type="bool" value="true" />
       </ParameterList>
+      <Parameter name="debug cells" type="Array(int)" value="{0}" />
 
     </ParameterList>
 
@@ -266,6 +268,7 @@
       <ParameterList name="diffusion" type="ParameterList">
         <Parameter name="discretization primary" type="string" value="mfd: two-point flux approximation" />
       </ParameterList>
+      <Parameter name="debug cells" type="Array(int)" value="{99}" />
 
       <ParameterList name="boundary conditions" type="ParameterList">
         <ParameterList name="temperature" type="ParameterList">
@@ -320,6 +323,7 @@
       <ParameterList name="diffusion" type="ParameterList">
         <Parameter name="discretization primary" type="string" value="fv: default" />
       </ParameterList>
+      <Parameter name="debug cells" type="Array(int)" value="{0}" />
 
       <ParameterList name="boundary conditions" type="ParameterList">
       </ParameterList>
@@ -351,6 +355,7 @@
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="0.35" />
       </ParameterList>
+      <Parameter name="debug cells" type="Array(int)" value="{0}" />
 
       <ParameterList name="inverse" type="ParameterList">
         <Parameter name="preconditioning method" type="string" value="identity" />
@@ -372,7 +377,7 @@
       <ParameterList name="water_content" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="liquid+ice water content" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/08_energy/permafrost-wrm_vangenuchten-krel_vangenuchten_orig.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_vangenuchten_orig.xml
@@ -197,7 +197,6 @@
       <Parameter name="domain name" type="string" value="domain" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="permeability rescaling" type="double" value="10000000" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="unsaturated" />
@@ -237,7 +236,6 @@
       <Parameter name="primary variable key" type="string" value="surface-pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-water_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="water source in meters" type="bool" value="true" />
       <Parameter name="initial time step" type="double" value="86400" />
       <ParameterList name="diffusion" type="ParameterList">
@@ -259,7 +257,6 @@
       <Parameter name="primary variable key" type="string" value="temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="initial time step" type="double" value="86400" />
       <Parameter name="include thermal advection" type="bool" value="false" />
       <Parameter name="explicit advection" type="bool" value="false" />
@@ -310,7 +307,6 @@
       <Parameter name="primary variable key" type="string" value="surface-temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="flux key" type="string" value="surface-water_flux" />
       <Parameter name="include thermal advection" type="bool" value="false" />
@@ -348,7 +344,6 @@
       <Parameter name="conserved quantity key" type="string" value="snow-water_volume" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key" type="string" value="snow-source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <ParameterList name="initial condition" type="ParameterList">
         <Parameter name="constant" type="double" value="0.35" />
       </ParameterList>

--- a/08_energy/permafrost-wrm_vangenuchten-krel_vangenuchten_orig.xml
+++ b/08_energy/permafrost-wrm_vangenuchten-krel_vangenuchten_orig.xml
@@ -373,7 +373,7 @@
       <ParameterList name="water_content" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="liquid+ice water content" />
       </ParameterList>
-      <ParameterList name="molar_density_liquid" type="ParameterList">
+      <ParameterList name="mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">
@@ -547,7 +547,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="snow-source_sink" type="ParameterList">
+      <ParameterList name="snow-density" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="surface energy balance, three components" />
         <Parameter name="save diagnostic data" type="bool" value="true" />
         <Parameter name="wind speed reference height [m]" type="double" value=" 3" />

--- a/08_energy/surface_water_orig.xml
+++ b/08_energy/surface_water_orig.xml
@@ -191,7 +191,6 @@
       <Parameter name="upwind conductivity method" type="string" value="arithmetic mean" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source term key" type="string" value="surface-total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0,9}" />
       <ParameterList name="verbose object" type="ParameterList">
         <Parameter name="verbosity level" type="string" value="high" />

--- a/09_multiscale_models/column_infiltration_hybrid.xml
+++ b/09_multiscale_models/column_infiltration_hybrid.xml
@@ -297,7 +297,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="water_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>
@@ -311,7 +310,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="energy_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>

--- a/09_multiscale_models/column_infiltration_hybrid.xml
+++ b/09_multiscale_models/column_infiltration_hybrid.xml
@@ -584,7 +584,7 @@
       <ParameterList name="surface_star-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="column:*-molar_density_liquid" type="ParameterList">
+      <ParameterList name="column:*-mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/09_multiscale_models/column_infiltration_pressure.xml
+++ b/09_multiscale_models/column_infiltration_pressure.xml
@@ -606,7 +606,7 @@
       <ParameterList name="surface_star-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="column:*-molar_density_liquid" type="ParameterList">
+      <ParameterList name="column:*-mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/09_multiscale_models/column_infiltration_pressure.xml
+++ b/09_multiscale_models/column_infiltration_pressure.xml
@@ -291,7 +291,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="water_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>
@@ -305,7 +304,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="energy_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>

--- a/09_multiscale_models/columnar_permafrost.xml
+++ b/09_multiscale_models/columnar_permafrost.xml
@@ -400,7 +400,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="modify predictor positivity preserving" type="bool" value="true" />
       <Parameter name="absolute error tolerance" type="double" value="0.01" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
@@ -458,7 +457,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="water_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>
@@ -472,7 +470,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="energy_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
@@ -485,7 +482,6 @@
       <Parameter name="domain name" type="string" value="column:*" />
       <Parameter name="primary variable key suffix" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source key suffix" type="string" value="water_source" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
@@ -523,7 +519,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="supress advective terms in preconditioner" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">

--- a/09_multiscale_models/columnar_permafrost.xml
+++ b/09_multiscale_models/columnar_permafrost.xml
@@ -755,7 +755,7 @@
       <ParameterList name="surface_star-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="column:*-molar_density_liquid" type="ParameterList">
+      <ParameterList name="column:*-mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/09_multiscale_models/columnar_permafrost_dynamic_subgrid.xml
+++ b/09_multiscale_models/columnar_permafrost_dynamic_subgrid.xml
@@ -498,7 +498,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content_snow" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="modify predictor positivity preserving" type="bool" value="true" />
       <Parameter name="absolute error tolerance" type="double" value="0.01" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
@@ -571,7 +570,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="mass source in meters" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="mass_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>
@@ -585,7 +583,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="energy_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
@@ -602,7 +599,6 @@
       <Parameter name="primary variable key suffix" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="source key suffix" type="string" value="mass_source" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="clobber" />
@@ -638,7 +634,6 @@
       <Parameter name="primary variable key suffix" type="string" value="temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="supress advective terms in preconditioner" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />

--- a/09_multiscale_models/columnar_permafrost_dynamic_subgrid.xml
+++ b/09_multiscale_models/columnar_permafrost_dynamic_subgrid.xml
@@ -1016,7 +1016,7 @@
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
         <Parameter name="depth key" type="string" value="surface_star-mobile_depth" />
       </ParameterList>
-      <ParameterList name="column:*-molar_density_liquid" type="ParameterList">
+      <ParameterList name="column:*-mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/09_multiscale_models/columnar_permafrost_subcycled.xml
+++ b/09_multiscale_models/columnar_permafrost_subcycled.xml
@@ -814,7 +814,7 @@
       <ParameterList name="surface_star-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="column:*-molar_density_liquid" type="ParameterList">
+      <ParameterList name="column:*-mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/09_multiscale_models/columnar_permafrost_subcycled.xml
+++ b/09_multiscale_models/columnar_permafrost_subcycled.xml
@@ -748,6 +748,9 @@
   </ParameterList>
 
   <ParameterList name="state" type="ParameterList">
+    <ParameterList name="debug" type="ParameterList">
+      <Parameter name="evaluators" type="Array(string)" value="{column:0-base_porosity}" />
+    </ParameterList>
     <ParameterList name="evaluators" type="ParameterList">
       <ParameterList name="column:*-water_content" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="liquid+ice water content" />

--- a/09_multiscale_models/columnar_permafrost_subcycled.xml
+++ b/09_multiscale_models/columnar_permafrost_subcycled.xml
@@ -432,7 +432,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="modify predictor positivity preserving" type="bool" value="true" />
       <Parameter name="absolute error tolerance" type="double" value="0.01" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
@@ -499,7 +498,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="water_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>
@@ -513,7 +511,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="energy_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
@@ -527,7 +524,6 @@
       <Parameter name="primary variable key suffix" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="source key suffix" type="string" value="water_source" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="clobber" />
@@ -564,7 +560,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="supress advective terms in preconditioner" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="diffusion" type="ParameterList">

--- a/09_multiscale_models/columnar_permafrost_subgrid.xml
+++ b/09_multiscale_models/columnar_permafrost_subgrid.xml
@@ -427,7 +427,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="modify predictor positivity preserving" type="bool" value="true" />
       <Parameter name="absolute error tolerance" type="double" value="0.01" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
@@ -487,7 +486,6 @@
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="mass source in meters" type="bool" value="false" />
       <Parameter name="source key suffix" type="string" value="water_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>
@@ -501,7 +499,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="energy_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="source term finite difference" type="bool" value="true" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
@@ -515,7 +512,6 @@
       <Parameter name="primary variable key suffix" type="string" value="pressure" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="source key suffix" type="string" value="water_source" />
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux" />
       <Parameter name="surface rel perm strategy" type="string" value="clobber" />
@@ -551,7 +547,6 @@
       <Parameter name="primary variable key suffix" type="string" value="temperature" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="total_energy_source" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="supress advective terms in preconditioner" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />

--- a/09_multiscale_models/columnar_permafrost_subgrid.xml
+++ b/09_multiscale_models/columnar_permafrost_subgrid.xml
@@ -908,7 +908,7 @@
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
         <Parameter name="depth key" type="string" value="surface_star-mobile_depth" />
       </ParameterList>
-      <ParameterList name="column:*-molar_density_liquid" type="ParameterList">
+      <ParameterList name="column:*-mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/09_multiscale_models/columnar_permafrost_subgrid.xml
+++ b/09_multiscale_models/columnar_permafrost_subgrid.xml
@@ -922,7 +922,7 @@
           <Parameter name="EOS type" type="string" value="liquid water" />
         </ParameterList>
       </ParameterList>
-      <ParameterList name="surface_star-molar_density_liquid" type="ParameterList">
+      <ParameterList name="surface_star-mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/09_multiscale_models/columns_lateral_flow_flux.xml
+++ b/09_multiscale_models/columns_lateral_flow_flux.xml
@@ -297,7 +297,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="water_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>
@@ -311,7 +310,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="energy_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>

--- a/09_multiscale_models/columns_lateral_flow_flux.xml
+++ b/09_multiscale_models/columns_lateral_flow_flux.xml
@@ -586,7 +586,7 @@
       <ParameterList name="surface_star-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="column:*-molar_density_liquid" type="ParameterList">
+      <ParameterList name="column:*-mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/09_multiscale_models/columns_lateral_flow_hybrid.xml
+++ b/09_multiscale_models/columns_lateral_flow_hybrid.xml
@@ -297,7 +297,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="water_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>
@@ -311,7 +310,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="energy_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>

--- a/09_multiscale_models/columns_lateral_flow_hybrid.xml
+++ b/09_multiscale_models/columns_lateral_flow_hybrid.xml
@@ -586,7 +586,7 @@
       <ParameterList name="surface_star-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="column:*-molar_density_liquid" type="ParameterList">
+      <ParameterList name="column:*-mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/09_multiscale_models/columns_lateral_flow_pressure.xml
+++ b/09_multiscale_models/columns_lateral_flow_pressure.xml
@@ -583,7 +583,7 @@
       <ParameterList name="surface_star-unfrozen_effective_depth" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="unfrozen effective depth" />
       </ParameterList>
-      <ParameterList name="column:*-molar_density_liquid" type="ParameterList">
+      <ParameterList name="column:*-mass_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
         <ParameterList name="EOS parameters" type="ParameterList">

--- a/09_multiscale_models/columns_lateral_flow_pressure.xml
+++ b/09_multiscale_models/columns_lateral_flow_pressure.xml
@@ -294,7 +294,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="water_content" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="water_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>
@@ -308,7 +307,6 @@
       <Parameter name="conserved quantity key suffix" type="string" value="energy" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="source key suffix" type="string" value="energy_source_sink" />
-      <Parameter name="source term is differentiable" type="bool" value="false" />
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <ParameterList name="initial condition" type="ParameterList">
       </ParameterList>

--- a/10_seawater_intrusion/integrated_hydrology_swi_flat.xml
+++ b/10_seawater_intrusion/integrated_hydrology_swi_flat.xml
@@ -276,7 +276,6 @@
       <Parameter name="domain name" type="string" value="surface" />
       <Parameter name="source term" type="bool" value="true" />
       <Parameter name="initial time step" type="double" value="10" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="min ponded depth for tidal bc" type="double" value="-2" />
       <Parameter name="debug cells" type="Array(int)" value="{299}" />
       <ParameterList name="verbose object" type="ParameterList">

--- a/10_seawater_intrusion/swi_lab_test_integrated_hydrology_steady_state.xml
+++ b/10_seawater_intrusion/swi_lab_test_integrated_hydrology_steady_state.xml
@@ -252,7 +252,6 @@
       <Parameter name="debug cells" type="Array(int)" value="{0}" />
       <Parameter name="mass source in meters" type="bool" value="true" />
       <Parameter name="initial time step" type="double" value=" 1" />
-      <Parameter name="source term is differentiable" type="bool" value="true" />
       <Parameter name="min ponded depth for tidal bc" type="double" value="-2" />
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="low" />

--- a/10_seawater_intrusion/swi_lab_test_integrated_hydrology_steady_state.xml
+++ b/10_seawater_intrusion/swi_lab_test_integrated_hydrology_steady_state.xml
@@ -445,6 +445,22 @@
       <ParameterList name="capillary_pressure_gas_liq" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="capillary pressure, atmospheric gas over liquid" />
       </ParameterList>
+
+      <ParameterList name="surface-mass_density_liquid" type="ParameterList">
+        <Parameter name="evaluator type" type="string" value="eos" />
+        <Parameter name="EOS basis" type="string" value="both" />
+        <Parameter name="molar density key" type="string" value="surface-molar_density_liquid" />
+        <Parameter name="mass density key" type="string" value="surface-mass_density_liquid" />
+        <Parameter name="concentration tag" type="string" value="current" />
+        <ParameterList name="EOS parameters" type="ParameterList">
+          <Parameter name="EOS type" type="string" value="salt water" />
+          <Parameter name="fresh water mass density [kg/m^3]" type="double" value="1000" />
+          <Parameter name="sea water density coefficient" type="double" value="700" />
+        </ParameterList>
+        <ParameterList name="verbose object" type="ParameterList">
+          <Parameter name="verbosity level" type="string" value="extreme" />
+        </ParameterList>
+      </ParameterList>
       <ParameterList name="surface-molar_density_liquid" type="ParameterList">
         <Parameter name="evaluator type" type="string" value="eos" />
         <Parameter name="EOS basis" type="string" value="both" />
@@ -460,6 +476,7 @@
           <Parameter name="verbosity level" type="string" value="extreme" />
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="surface-source_molar_density">
         <Parameter name="evaluator type" type="string" value="independent variable constant" />
         <Parameter name="value" type="double" value="55500" />


### PR DESCRIPTION
This PR is joint with amanzi/ats#270 and amanzi/amanzi#860.

Those PRs:

1. make it so that we don't need "source term is differentiable", as the PK can just ask the evaluator. (see amanzi/ats#167)
2. This also potentially changes the order of which evaluators are created; as such some evaluators which create multiple variables (e.g. molar_density_liquid and mass_density_liquid), now the _other_ variable is required first.  There is currently no good way of dealing with this in Amanzi-ATS, so we're stuck changing the name in the input file.  This is going to annoy people, but maybe we can just script the duplication of the list under both names in the input converter?