### PR TITLE
add testing_no_geochemistry suite

### DIFF
--- a/00_analytic/analytic.cfg
+++ b/00_analytic/analytic.cfg
@@ -1,6 +1,8 @@
 [suites]
 testing = exponential_decay
 
+testing_no_geochemistry = exponential_decay
+
 [default-test-criteria]
 # default criteria for all tests, can be overwritten by specific tests
 default = 1.0e-5 relative

--- a/01_richards_steadystate/richards_steadystate.cfg
+++ b/01_richards_steadystate/richards_steadystate.cfg
@@ -1,6 +1,8 @@
 [suites]
 testing = fv mfd
 
+testing_no_geochemistry = fv mfd
+
 [default-test-criteria]
 # default criteria for all tests, can be overwritten by specific tests
 default = 1.0e-8 relative

--- a/02_richards/richards.cfg
+++ b/02_richards/richards.cfg
@@ -6,7 +6,12 @@ testing = infiltration_fv infiltration_mfd infiltration_brooks_corey_mfd
         infiltration_then_seepage_fv infiltration_then_seepage_mfd
         seepage_drawdown_diag_tensor_fv seepage_drawdown_diag_tensor_mfd seepage_drawdown_full_tensor_mfd
 
-
+testing_no_geochemistry = infiltration_fv infiltration_mfd infiltration_brooks_corey_mfd
+        seepage_infiltration_fv seepage_infiltration_mfd
+        seepage_drawdown_fv seepage_drawdown_mfd
+        seepage_exfiltration_fv seepage_exfiltration_mfd
+        infiltration_then_seepage_fv infiltration_then_seepage_mfd
+        seepage_drawdown_diag_tensor_fv seepage_drawdown_diag_tensor_mfd seepage_drawdown_full_tensor_mfd
 
 [default-test-criteria]
 # default criteria for all tests, can be overwritten by specific tests

--- a/03_surface_water/surface_water.cfg
+++ b/03_surface_water/surface_water.cfg
@@ -3,6 +3,10 @@ testing = rainfall_fv_simplified rainfall_fv rainfall_fv_jac
         bc_max_head bc_zero_gradient bc_critical_depth
         snow_distribution
 
+testing_no_geochemistry = rainfall_fv_simplified rainfall_fv rainfall_fv_jac
+        bc_max_head bc_zero_gradient bc_critical_depth
+        snow_distribution
+
 [default-test-criteria]
 default = 1.0e-8 absolute
 

--- a/04_integrated_hydro/integrated_hydro.cfg
+++ b/04_integrated_hydro/integrated_hydro.cfg
@@ -3,6 +3,10 @@ testing = column_sat column_inf
         column_infiltration2 column_drainage column_exfiltration
         hillslope_sat-np2 hillslope_inf-np2 1d_dist_tiles 3d_dist_tiles-np2
 
+testing_no_geochemistry = column_sat column_inf
+        column_infiltration2 column_drainage column_exfiltration
+        hillslope_sat-np2 hillslope_inf-np2 1d_dist_tiles 3d_dist_tiles-np2
+
 [default-test-criteria]
 # default criteria for all tests, can be overwritten by specific tests
 default = 1.0e-8 relative

--- a/05_surface_balance/surface_balance.cfg
+++ b/05_surface_balance/surface_balance.cfg
@@ -1,5 +1,9 @@
 [suites]
-testing = general priestley_taylor priestley_taylor_trf_relperm lingzhang_rsoil-sakagucki_zeng lingzhang_rsoil-sellers
+testing = general priestley_taylor priestley_taylor_trf_relperm 
+        lingzhang_rsoil-sakagucki_zeng lingzhang_rsoil-sellers
+
+testing_no_geochemistry = general priestley_taylor priestley_taylor_trf_relperm 
+        lingzhang_rsoil-sakagucki_zeng lingzhang_rsoil-sellers
 
 [default-test-criteria]
 # default criteria for all tests, can be overwritten by specific tests

--- a/06_transport/transport.cfg
+++ b/06_transport/transport.cfg
@@ -2,6 +2,9 @@
 testing = surface_tracer subsurface_tracer
         column_infiltration column_exfiltration column_drainage 
 
+testing_no_geochemistry = surface_tracer subsurface_tracer
+        column_infiltration column_exfiltration column_drainage 
+
 reactive_transport = surface_tracer subsurface_tracer
         column_infiltration column_exfiltration column_drainage diffuse_three
 

--- a/08_energy/energy.cfg
+++ b/08_energy/energy.cfg
@@ -1,5 +1,13 @@
 [suites]
-testing = freeze_thaw_surface freeze_thaw_subsurface surface_transport surface_water coupled_flow_energy1 coupled_flow_energy2 coupled_flow_energy3 permafrost-wrm_vangenuchten-krel_vangenuchten permafrost-wrm_vangenuchten-krel_brookscorey permafrost-wrm_vangenuchten-krel_sutraice permafrost-wrm_brookscorey-krel_brookscorey
+testing = freeze_thaw_surface freeze_thaw_subsurface surface_transport surface_water 
+        coupled_flow_energy1 coupled_flow_energy2 coupled_flow_energy3 
+        permafrost-wrm_vangenuchten-krel_vangenuchten permafrost-wrm_vangenuchten-krel_brookscorey 
+        permafrost-wrm_vangenuchten-krel_sutraice permafrost-wrm_brookscorey-krel_brookscorey
+
+testing_no_geochemistry = freeze_thaw_surface freeze_thaw_subsurface surface_transport surface_water 
+        coupled_flow_energy1 coupled_flow_energy2 coupled_flow_energy3 
+        permafrost-wrm_vangenuchten-krel_vangenuchten permafrost-wrm_vangenuchten-krel_brookscorey 
+        permafrost-wrm_vangenuchten-krel_sutraice permafrost-wrm_brookscorey-krel_brookscorey
 
 [default-test-criteria]
 # default criteria for all tests, can be overwritten by specific tests

--- a/09_multiscale_models/multiscale.cfg
+++ b/09_multiscale_models/multiscale.cfg
@@ -16,6 +16,10 @@ testing = stream_hyporheic_conservative_tracer_reach
         column_infiltration_pressure
         column_infiltration_hybrid
 
+testing_no_geochemistry = stream_hyporheic_conservative_tracer_reach
+        column_infiltration_pressure
+        column_infiltration_hybrid
+
 reactive_transport = stream_hyporheic_conservative_tracer_reach
         stream_hyporheic_conservative_tracer_reach_multisubgrid
         stream_hyporheic_denitrification_reach

--- a/10_seawater_intrusion/seawater_intrusion.cfg
+++ b/10_seawater_intrusion/seawater_intrusion.cfg
@@ -1,6 +1,8 @@
 [suites]
 testing = henry_problem_mfd swi_lab_test_integrated_hydrology_steady_state
 
+testing_no_geochemistry = henry_problem_mfd swi_lab_test_integrated_hydrology_steady_state
+
 [default-test-criteria]
 # default criteria for all tests, can be overwritten by specific tests
 default = 1.0e-8 relative


### PR DESCRIPTION
Adds a new testing_no_geochemistry test suite to omit the tests requiring geochemistry TPLs when ATS is built with --disable-geochemistry. 

Ref ATS issue https://github.com/amanzi/ats/issues/248